### PR TITLE
added support for clusters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 shell:
 	docker-compose run --rm python sh
 
+.PHONY: python
 python:
 	docker-compose run --rm python python
 
@@ -9,7 +10,7 @@ environment:
 
 clean:
 	docker-compose down
-	rm -rf .pytest_cache .coverage __pycache__
+	rm -rf .pytest_cache .coverage __pycache__ python/__pycache__
 
 .PHONY: tests
 tests:

--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
 # cloud-formation-rds-properties
 
-## A Lambda backed custom resource for CloudFormation that provides information about an RDS instance
+## A Lambda backed custom resource for CloudFormation that provides information about an RDS instance or cluster
 
 [![CircleCI](https://circleci.com/gh/RealSalmon/cloud-formation-rds-properties.svg?style=svg)](https://circleci.com/gh/RealSalmon/cloud-formation-rds-properties)
 
 ### Purpose:
-This custom resource provides information about an AWS RDS instance.
+This custom resource provides information about an AWS RDS instance or cluster.
 
-It might be useful in situations where your RDS instance is outside of a
+It might be useful in situations where your RDS resource is outside of a
 CloudFormation stack where it would be helpful to have that information without
 the need to enter several parameters. It might also be helpful in situations
-where you need additional information about an RDS instance that the return
-values for a AWS::RDS::DBInstance type do not include.
+where you need additional information about an RDS resource that the return
+values for AWS::RDS::DBInstance and AWS::RDS::DBCluster do not include.
 
 ### Installation
 This custom resource can be installed on your AWS account by deploying the 
@@ -33,8 +33,9 @@ RdsProperties:
   Type: "AWS::CloudFormation::CustomResource"
   Version: "1.0"
   Properties:
-    ServiceToken: LAMDA_FUNCTION_ARN,
-    DBInstanceIdentifier: DB_INSTANCE_IDENTIFIER,
+    ServiceToken: LAMDA_FUNCTION_ARN
+    DBInstanceIdentifier: DB_INSTANCE_IDENTIFIER
+    DBClusterIdentifier: DB_CLUSTER_IDENTIFIER,
 ```
 ### Properties
 
@@ -45,10 +46,18 @@ Type: String
 Required: Yes
 
 #### DBInstanceIdentifier
-##### The DBInstanceIdentifier of the RDS instance to query
+##### The DBInstanceIdentifier of an RDS instance to query
 Type: String
 
-Required: Yes
+Required: Conditional. Exactly one of either DBInstanceIdentifier or 
+DBClusterIdentifier are required
+
+#### DBClusterIdentifier
+##### The DBClusterIdentifier of an RDS cluster to query
+Type: String
+
+Required: Conditional. Exactly one of either DBInstanceIdentifier or 
+DBClusterIdentifier are required
 
 
 ### Return Values
@@ -61,26 +70,32 @@ Ref returns the DBInstanceIdentifier property
 Fn::GetAtt returns a value for a specified attribute of this type. The 
 following are the available attributes.
 
-##### DBInstanceArn
-The ARN of the RDS instance
+##### Arn
+The ARN of the RDS resource.
 
-##### DbiResourceId
-The AWS Region-unique, immutable identifier for the DB instance.
+##### ResourceId
+The AWS Region-unique, immutable identifier for the RDS resource. For 
+instances, this will be the DbiResourceId. For clusters, this will be the 
+DbClusterResourceId.
 
 ##### DBName
-The name of the database that was created with the RDS instance
+The name of the database that was created with the RDS resource
 
 ##### Endpoint.Address
-The endpoint address of the RDS instance
+The endpoint address of the RDS resource
 
 ##### Endpoint.Port
-The endpoint port of the RDS instance
+The endpoint port of the RDS resource
+
+#### ReadEndpoint.Address
+The reader endpoint for the RDS resource. For instances, this will always be
+the same as Endpoint.Address
 
 ##### Engine
-The engine of the RDS instance
+The engine of the RDS resource
 
 ##### EngineVersion
-The engine version of the RDS instance
+The engine version of the RDS resource
 
 ##### IAMDatabaseAuthenticationEnabled
 True if mapping of AWS Identity and Access Management (IAM) accounts to 

--- a/cloud-formation/cloud-formation.yml
+++ b/cloud-formation/cloud-formation.yml
@@ -2,7 +2,7 @@
 
 AWSTemplateFormatVersion: "2010-09-09"
 
-Description: "A Lambda backed custom resource for CloudFormation that provides information about an RDS instance"
+Description: "A Lambda backed custom resource for CloudFormation that provides information about an RDS instance or cluster"
 
 Parameters:
 
@@ -30,13 +30,14 @@ Resources:
       ManagedPolicyArns:
         - "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
       Policies:
-        - PolicyName: "describe-db-instances"
+        - PolicyName: "describe-rds-resources"
           PolicyDocument:
             Version: "2012-10-17"
             Statement:
               - Effect: "Allow"
                 Action:
                   - "rds:DescribeDbInstances"
+                  - "rds:DescribeDbClusters"
                 Resource: "*"
 
   # Lambda function to back the custom resource
@@ -47,7 +48,7 @@ Resources:
       FunctionName: !Ref LambdaFunctionName
       Code:
         ZipFile: "def lambda_handler(event, context): return 'Hello World!'"
-      Description: "Custom resource for CloudFormation that describes an RDS instance"
+      Description: "Custom resource for CloudFormation that describes an RDS resource"
       Handler: "index.lambda_handler"
       MemorySize: 128
       Role: !GetAtt ["IamRole", "Arn"]

--- a/cloud-formation/example-cloud-formation.yml
+++ b/cloud-formation/example-cloud-formation.yml
@@ -7,12 +7,21 @@ Description: "Test stack for the cloud-formation-rds-properties custom resource"
 Parameters:
 
   RdsPropertiesStackname:
-    Type: "String"
     Description: "The CloudFormation stack name containing the rds-properties resource"
-
-  DBInstanceIdentifier:
     Type: "String"
-    Description: "The DBInstanceIdentifier of the RDS instance to use"
+
+  DbIdentifier:
+    Description: "The DbInstanceIdentifier or DbClusterIdentifier of the RDS resource to connect to"
+    Type: "String"
+
+  DbIdentifierType:
+    Description: "\"cluster\" or \"instance\" depending on the type of DbIdentifier"
+    Type: "String"
+    AllowedValues: ["cluster", "instance"]
+
+Conditions:
+  DbIdentifierIsInstance: !Equals [!Ref "DbIdentifierType", "instance"]
+  DbIdentifierIsCluster: !Equals [!Ref "DbIdentifierType", "cluster"]
 
 Resources:
 
@@ -23,28 +32,39 @@ Resources:
       ServiceToken:
         Fn::ImportValue:
           !Sub "${RdsPropertiesStackname}-FunctionArn"
-      DBInstanceIdentifier: !Ref "DBInstanceIdentifier"
+      DBInstanceIdentifier: !If
+        - "DbIdentifierIsInstance"
+        - !Ref "DbIdentifier"
+        - !Ref "AWS::NoValue"
+      DBClusterIdentifier: !If
+        - "DbIdentifierIsCluster"
+        - !Ref "DbIdentifier"
+        - !Ref "AWS::NoValue"
 
 Outputs:
-  DBInstanceArn:
-    Description: "The ARN of the RDS instance"
-    Value: !GetAtt ["RdsProperties", "DBInstanceArn"]
+  Arn:
+    Description: "The ARN of the RDS Resource"
+    Value: !GetAtt ["RdsProperties", "Arn"]
 
-  DbiResourceId:
-    Description: "The AWS Region-unique, immutable identifier for the DB instance."
-    Value: !GetAtt ["RdsProperties", "DbiResourceId"]
+  ResourceId:
+    Description: "The AWS Region-unique, immutable identifier for the RDS resource"
+    Value: !GetAtt ["RdsProperties", "ResourceId"]
 
   DBName:
-    Description: "The name of the database that was created with the RDS instance"
+    Description: "The name of the database that was created with the RDS resource"
     Value: !GetAtt ["RdsProperties", "DBName"]
 
   EndpointAddress:
-    Description: "The endpoint address of the RDS instance"
+    Description: "The endpoint address of the RDS resource"
     Value: !GetAtt ["RdsProperties", "Endpoint.Address"]
 
   EndpointPort:
-    Description: "The endpoint port of the RDS instance"
+    Description: "The endpoint port of the RDS resource"
     Value: !GetAtt ["RdsProperties", "Endpoint.Port"]
+
+  ReadEndpointAddress:
+    Description: "The read endpoint address of the RDS resource"
+    Value: !GetAtt ["RdsProperties", "ReadEndpoint.Address"]
 
   Engine:
     Description: "The engine of the RDS instance"

--- a/python/index.py
+++ b/python/index.py
@@ -28,6 +28,21 @@ logger = logging.getLogger(__name__)
 logging.basicConfig()
 logger.setLevel(os.environ.get("LOGLEVEL", "INFO").upper())
 
+MSG_EMPTY_PROPS = 'Empty resource properties'
+MSG_AMBIGUOUS_PROPS = 'DBInstanceIdentifier and DBClusterIdentifier can not ' \
+                      'both be specified in the resource properties'
+MSG_MISSING_PROPS = 'Required resource property DBInstanceIdentifier or ' \
+                    'DBClusterIdentifier is not set'
+
+
+def get_data_value(data_key, resource, data_map):
+    resource_key = data_map[data_key]
+    if '.' in resource_key:
+        x, y = resource_key.split('.')
+        return resource[x][y]
+    else:
+        return resource[resource_key]
+
 
 def send_response(request, response, status=None, reason=None):
     """ Send our response to the pre-signed URL supplied by CloudFormation
@@ -74,57 +89,85 @@ def lambda_handler(event, context=None):
         'Status': 'SUCCESS'
     }
 
-    # Make sure the correct params were sent
+    # Make sure resource properties are there
+    props = None
     try:
-        rds_id = event['ResourceProperties']['DBInstanceIdentifier']
+        props = event['ResourceProperties']
     except KeyError:
-        return send_fail(
-            event,
-            response,
-            'Required resource property DBInstanceIdentifier is not set'
-        )
+        return send_fail(event, response, MSG_EMPTY_PROPS)
+
+    # Make sure that we have one of DBInstanceIdentifier or DBClusterIdentifier
+    # but not both
+    inputs = ('DBInstanceIdentifier', 'DBClusterIdentifier')
+    arg_chk = [k in props for k in inputs]
+    if all(arg_chk):
+        return send_fail(event, response, MSG_AMBIGUOUS_PROPS)
+    elif not any(arg_chk):
+        return send_fail(event, response, MSG_MISSING_PROPS)
+
+    # At this point it is known that only one of these is a thing
+    isc = False
+    try:
+        resource_id = props['DBClusterIdentifier']
+        fxname = 'describe_db_clusters'
+        fxargs = {'DBClusterIdentifier': resource_id}
+        response_key = 'DBClusters'
+    except KeyError:
+        resource_id = props['DBInstanceIdentifier']
+        fxname = 'describe_db_instances'
+        fxargs = {'DBInstanceIdentifier': resource_id}
+        response_key = 'DBInstances'
+        isc = True
 
     # PhysicalResourceId is meaningless here, but CloudFormation requires it
     # returning the RDS instance ID seems to make the most sense...
-    response['PhysicalResourceId'] = rds_id
+    response['PhysicalResourceId'] = resource_id
 
     # There is nothing to do for a delete request as no actual resources
     # are being managed
     if event['RequestType'] == 'Delete':
         return send_response(event, response)
 
-    # Lookup the instance details
+    # Lookup the resource details
     try:
         client = boto3.client('rds')
-        instances = client.describe_db_instances(DBInstanceIdentifier=rds_id)
-        logger.info("AWS response was: %s", instances)
-        instance = instances['DBInstances'][0]
+        fx = getattr(client, fxname)
+        resources = fx(**fxargs)
+        logger.info("AWS response was: %s", resources)
+        resource = resources[response_key][0]
     except Exception as E:
         return send_fail(event, response, str(E))
 
-    # Set the response data
-    response['Data'] = {}
-    props = [
-        'Engine', 'EngineVersion',
-        'DBName', 'MasterUsername', 'DBInstanceArn',
-        'Endpoint.Address', 'Endpoint.Port',
-    ]
+    # map CF response data to query response keys
+    data_map = {
+        'Engine': 'Engine',
+        'EngineVersion': 'EngineVersion',
+        'MasterUsername': 'MasterUsername',
+        'IAMDatabaseAuthenticationEnabled': 'IAMDatabaseAuthenticationEnabled',
+        'DBName': 'DBName' if isc else 'DatabaseName',
+        'Endpoint.Address': 'Endpoint.Address' if isc else 'Endpoint',
+        'Endpoint.Port': 'Endpoint.Port' if isc else 'Port',
+        'ReadEndpoint.Address': 'Endpoint.Address' if isc else 'ReaderEndpoint',
+        'ResourceId': 'DbiResourceId' if isc else 'DbClusterResourceId',
+        'Arn': 'DBInstanceArn' if isc else 'DBClusterArn'
+    }
 
     # the moto library does not currently include these keys in its
     # mock of the describe_db_instances response so we'll ignore them
     # during testing
     #
     # https://github.com/spulec/moto/issues/1465
-    if 'pytest' not in sys.modules:
-        props += ['IAMDatabaseAuthenticationEnabled', 'DbiResourceId']
+    if 'pytest' in sys.modules:
+        del data_map['IAMDatabaseAuthenticationEnabled']
+        del data_map['ResourceId']
 
-    for prop in props:
-        if '.' in prop:
-            x, y = prop.split('.')
-            val = instance[x][y]
-        else:
-            val = instance[prop]
-
-        response['Data'][prop] = val
+    # Set the response data
+    try:
+        response['Data'] = {
+            data_key:get_data_value(data_key, resource, data_map)
+            for data_key in data_map
+        }
+    except Exception as E:
+        return send_fail(event, response, str(E))
 
     return send_response(event, response)

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -1,6 +1,7 @@
 import boto3
 from moto import mock_rds
 from index import lambda_handler
+from index import MSG_EMPTY_PROPS, MSG_AMBIGUOUS_PROPS, MSG_MISSING_PROPS
 
 
 def get_event():
@@ -13,17 +14,40 @@ def get_event():
     }
 
 
-def test_missing_params():
+def test_empty_params():
     event = get_event()
-    event['ResourceProperties'] = {"SomeGarbage": "DoNotWant"}
+    del event['ResourceProperties']
     response = lambda_handler(event)
     assert 'Status' in response
     assert response['Status'] == 'FAILED'
     assert response['StackId'] == event['StackId']
     assert response['LogicalResourceId'] == event['LogicalResourceId']
     assert response['RequestId'] == event['RequestId']
-    assert response['Reason'] == 'Required resource property ' \
-                                 'DBInstanceIdentifier is not set'
+    assert response['Reason'] == MSG_EMPTY_PROPS
+
+
+def test_ambiguous_params():
+    event = get_event()
+    event['ResourceProperties']['DBClusterIdentifier'] = 'my-cluster'
+    response = lambda_handler(event)
+    assert 'Status' in response
+    assert response['Status'] == 'FAILED'
+    assert response['StackId'] == event['StackId']
+    assert response['LogicalResourceId'] == event['LogicalResourceId']
+    assert response['RequestId'] == event['RequestId']
+    assert response['Reason'] == MSG_AMBIGUOUS_PROPS
+
+
+def test_missing_params():
+    event = get_event()
+    event['ResourceProperties'] = {'SomeGarbage': 'DoNotWant'}
+    response = lambda_handler(event)
+    assert 'Status' in response
+    assert response['Status'] == 'FAILED'
+    assert response['StackId'] == event['StackId']
+    assert response['LogicalResourceId'] == event['LogicalResourceId']
+    assert response['RequestId'] == event['RequestId']
+    assert response['Reason'] == MSG_MISSING_PROPS
 
 
 def test_delete():
@@ -37,7 +61,7 @@ def test_delete():
 
 
 @mock_rds
-def test_no_such_db():
+def test_no_such_instance():
     event = get_event()
     response = lambda_handler(event)
     assert 'Status' in response
@@ -51,7 +75,7 @@ def test_no_such_db():
 
 
 @mock_rds
-def test_success():
+def test_success_instance():
 
     instance_id = 'my-rds-instance'
     database_name = 'my-database'
@@ -87,8 +111,74 @@ def test_success():
     assert data['DBName'] == database_name
     assert data['Engine'] == engine
     assert data['EngineVersion'] == engine_version
-    # assert data['IAMDatabaseAuthenticationEnabled'] is True
-    assert 'DBInstanceArn' in data
+    assert 'Arn' in data
     assert 'Endpoint.Port' in data
     assert 'Endpoint.Address' in data
-    # assert 'DbiResourceId' in data
+    assert 'ReadEndpoint.Address' in data
+    assert data['ReadEndpoint.Address'] == data['Endpoint.Address']
+
+    # These are not supported by moto
+    # assert data['IAMDatabaseAuthenticationEnabled'] is True
+    # assert 'ResourceId' in data
+
+
+# moto has not implemented create_db_cluster so we'll skip these for now
+
+@mock_rds
+def skip_test_no_such_cluster():
+    event = get_event()
+    event["ResourceProperties"] = {"DBClusterIdentifier": "some-cluster"}
+    response = lambda_handler(event)
+    assert 'Status' in response
+    assert response['Status'] == 'FAILED'
+    assert response['StackId'] == event['StackId']
+    assert response['LogicalResourceId'] == event['LogicalResourceId']
+    assert response['RequestId'] == event['RequestId']
+    assert response['Reason'] == 'An error occurred (DBClusterNotFound) ' \
+                                 'when calling the DescribeDBClusters ' \
+                                 'operation: Cluster some-cluster not found.'
+
+
+@mock_rds
+def skip_test_success_cluster():
+
+    cluster_id = 'my-rds-cluster'
+    database_name = 'my-database'
+    engine = 'mysql'
+    engine_version = '1.2.3'
+    master_username = 'root'
+
+    # Create the database cluster
+    client = boto3.client('rds')
+    client.create_db_cluster(
+        DatabaseName=database_name,
+        DBClusterIdentifier=cluster_id,
+        Engine=engine,
+        EngineVersion=engine_version,
+        MasterUsername=master_username,
+        MasterUserPassword='override all security',
+        EnableIAMDatabaseAuthentication=True
+    )
+
+    event = get_event()
+    event['ResourceProperties']['DBClusterIdentifier'] = cluster_id
+    response = lambda_handler(event)
+    assert response['Status'] == 'SUCCESS'
+    assert response['StackId'] == event['StackId']
+    assert response['LogicalResourceId'] == event['LogicalResourceId']
+    assert response['PhysicalResourceId'] == cluster_id
+    assert response['RequestId'] == event['RequestId']
+
+    data = response['Data']
+    assert data['MasterUsername'] == master_username
+    assert data['DatabaseName'] == database_name
+    assert data['Engine'] == engine
+    assert data['EngineVersion'] == engine_version
+    assert 'Arn' in data
+    assert 'Endpoint.Port' in data
+    assert 'Endpoint.Address' in data
+    assert 'ReadEndpoint.Address' in data
+
+    # These are not supported by moto
+    # assert data['IAMDatabaseAuthenticationEnabled'] is True
+    # assert 'ResourceId' in data


### PR DESCRIPTION
- BREAKING CHANGE: drop support for "DBInstanceArn" return value. Use "Arn" instead.
- BREAKING CHANGE: drop support for "DbiResourceId" return value. Use "ResourceId" instead"
- added new return value "ReadEndpoint.Address" to support the related cluster value. For instances this will always be the same as "Endpoint.Address"