### PR TITLE
Add support for optional parameters, e.g. Database Name

### DIFF
--- a/python/index.py
+++ b/python/index.py
@@ -39,9 +39,9 @@ def get_data_value(data_key, resource, data_map):
     resource_key = data_map[data_key]
     if '.' in resource_key:
         x, y = resource_key.split('.')
-        return resource.get(x, {}).get(y, "na")
+        return resource[x][y]
     else:
-        return resource.get(resource_key, "na")
+        return resource.get(resource_key)
 
 
 def send_response(request, response, status=None, reason=None):

--- a/python/index.py
+++ b/python/index.py
@@ -39,9 +39,9 @@ def get_data_value(data_key, resource, data_map):
     resource_key = data_map[data_key]
     if '.' in resource_key:
         x, y = resource_key.split('.')
-        return resource[x][y]
+        return resource.get(x, {}).get(y, "na")
     else:
-        return resource[resource_key]
+        return resource.get(resource_key, "na")
 
 
 def send_response(request, response, status=None, reason=None):


### PR DESCRIPTION
When you create an RDS instance it is not required to specify a "Database Name" so if one was not created when the RDS instance was created a Custom Resource that references this instance/cluster is returning an error.